### PR TITLE
Add `en-gb` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 | Code            | Flag | Language                         | Main Region | 42               |
 | --------------- | ---- | -------------------------------- | ----------- | ---------------- |
+| `en`, `en-gb`   | 🇬🇧   | British English                  | UK          | forty-two        |
 | `en`, `en-us`   | 🇺🇸   | American English                 | USA         | forty-two        |
 | `fr`, `fr-fr`   | 🇫🇷   | French, Français                 | France      | quarante-deux    |
 | `it`, `it-it`   | 🇮🇹   | Italiano                         | Italy       | quarantadue      |
@@ -261,6 +262,9 @@ fmt.Println(ntw.IntegerToFrFr(42)) // french
 ```go
 fmt.Println(ntw.IntegerToFrBe(92)) // belgian french
 // Outputs: nonante-deux
+
+fmt.Println(ntw.IntegerToEnGb(42)) // british english
+// Outputs: forty-two
 
 fmt.Println(ntw.IntegerToEnUs(42)) // american english
 // Outputs: forty-two

--- a/en-gb.go
+++ b/en-gb.go
@@ -1,0 +1,100 @@
+package ntw
+
+import (
+	"fmt"
+	"strings"
+)
+
+func init() {
+	// register the language
+	Languages["en-gb"] = Language{
+		Name:    "British English",
+		Aliases: []string{"en", "en-gb", "es_GB", "british", "english"},
+		Flag:    "🇬🇧",
+
+		IntegerToWords: IntegerToEnGb,
+	}
+}
+
+// IntegerToEnGb converts an integer to British English words
+func IntegerToEnGb(input int) string {
+	var englishMegas = []string{"", "thousand", "million", "billion", "trillion", "quadrillion", "quintillion", "sextillion", "septillion", "octillion", "nonillion", "decillion", "undecillion", "duodecillion", "tredecillion", "quattuordecillion"}
+	var englishUnits = []string{"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
+	var englishTens = []string{"", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"}
+	var englishTeens = []string{"ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"}
+
+	words := []string{}
+
+	if input < 0 {
+		words = append(words, "minus")
+		input *= -1
+	}
+
+	// split integer in triplets
+	triplets := integerToTriplets(input)
+
+	// zero is a special case
+	if len(triplets) == 0 {
+		return "zero"
+	}
+
+	// iterate over triplets
+	for idx := len(triplets) - 1; idx >= 0; idx-- {
+		triplet := triplets[idx]
+
+		// nothing todo for empty triplet
+		if triplet == 0 {
+			continue
+		}
+
+		// three-digits
+		hundreds := triplet / 100 % 10
+		tens := triplet / 10 % 10
+		units := triplet % 10
+
+		if hundreds > 0 {
+			words = append(words, englishUnits[hundreds], "hundred")
+		}
+
+		if tens == 0 && units == 0 {
+			goto tripletEnd
+		}
+
+		if hundreds > 0 && (tens > 0 || units > 0) {
+			words = append(words, "and")
+		}
+
+		switch tens {
+		case 0:
+			words = append(words, englishUnits[units])
+		case 1:
+			words = append(words, englishTeens[units])
+			break
+		default:
+			if units > 0 {
+				word := fmt.Sprintf("%s-%s", englishTens[tens], englishUnits[units])
+				words = append(words, word)
+			} else {
+				words = append(words, englishTens[tens])
+			}
+			break
+		}
+
+	tripletEnd:
+		// mega
+		if mega := englishMegas[idx]; mega != "" {
+			words = append(words, mega)
+		}
+
+		if idx > 0 {
+			words = append(words, ",")
+		}
+	}
+
+	var result string
+	result = strings.Join(words, " ")
+	result = strings.Replace(result, " ,", ",", -1)
+	result = strings.TrimSuffix(result, ",")
+
+	return result
+}

--- a/en-gb.go
+++ b/en-gb.go
@@ -69,7 +69,6 @@ func IntegerToEnGb(input int) string {
 			words = append(words, englishUnits[units])
 		case 1:
 			words = append(words, englishTeens[units])
-			break
 		default:
 			if units > 0 {
 				word := fmt.Sprintf("%s-%s", englishTens[tens], englishUnits[units])
@@ -77,7 +76,6 @@ func IntegerToEnGb(input int) string {
 			} else {
 				words = append(words, englishTens[tens])
 			}
-			break
 		}
 
 	tripletEnd:

--- a/en-gb_test.go
+++ b/en-gb_test.go
@@ -1,0 +1,74 @@
+package ntw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleIntegerToEnGb() {
+	fmt.Println(IntegerToEnGb(42))
+	// Output: forty-two
+}
+
+func TestIntegerToEnGb(t *testing.T) {
+	t.Parallel()
+
+	tests := map[int]string{
+		-1:            "minus one",
+		0:             "zero",
+		1:             "one",
+		9:             "nine",
+		10:            "ten",
+		11:            "eleven",
+		19:            "nineteen",
+		20:            "twenty",
+		21:            "twenty-one",
+		80:            "eighty",
+		90:            "ninety",
+		99:            "ninety-nine",
+		100:           "one hundred",
+		101:           "one hundred and one",
+		111:           "one hundred and eleven",
+		120:           "one hundred and twenty",
+		121:           "one hundred and twenty-one",
+		900:           "nine hundred",
+		909:           "nine hundred and nine",
+		919:           "nine hundred and nineteen",
+		990:           "nine hundred and ninety",
+		999:           "nine hundred and ninety-nine",
+		1000:          "one thousand",
+		2000:          "two thousand",
+		4000:          "four thousand",
+		5000:          "five thousand",
+		11000:         "eleven thousand",
+		21000:         "twenty-one thousand",
+		999000:        "nine hundred and ninety-nine thousand",
+		999999:        "nine hundred and ninety-nine thousand, nine hundred and ninety-nine",
+		1000000:       "one million",
+		2000000:       "two million",
+		4000000:       "four million",
+		5000000:       "five million",
+		100100100:     "one hundred million, one hundred thousand, one hundred",
+		500500500:     "five hundred million, five hundred thousand, five hundred",
+		606606606:     "six hundred and six million, six hundred and six thousand, six hundred and six",
+		999000000:     "nine hundred and ninety-nine million",
+		999000999:     "nine hundred and ninety-nine million, nine hundred and ninety-nine",
+		999999000:     "nine hundred and ninety-nine million, nine hundred and ninety-nine thousand",
+		999999999:     "nine hundred and ninety-nine million, nine hundred and ninety-nine thousand, nine hundred and ninety-nine",
+		1174315110:    "one billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and ten",
+		1174315119:    "one billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen",
+		15174315119:   "fifteen billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen",
+		35174315119:   "thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen",
+		935174315119:  "nine hundred and thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen",
+		2935174315119: "two trillion, nine hundred and thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen",
+	}
+
+	for input, expectedOutput := range tests {
+		name := fmt.Sprintf("%d", input)
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, expectedOutput, IntegerToEnGb(input))
+		})
+	}
+}


### PR DESCRIPTION
I implemented `en-gb`, which includes the word `and` between each mega, and commas to separate the megas.

I wasn't sure what to do about the `en` alias, so any input would be great.

Examples:
```
1174315110:    "one billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and ten"
1174315119:    "one billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen"
15174315119:   "fifteen billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen"
35174315119:   "thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen"
935174315119:  "nine hundred and thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen"
2935174315119: "two trillion, nine hundred and thirty-five billion, one hundred and seventy-four million, three hundred and fifteen thousand, one hundred and nineteen"
```