### PR TITLE
min, not minder. Minder means less.

### DIFF
--- a/de-de.go
+++ b/de-de.go
@@ -27,7 +27,7 @@ func IntegerToDeDe(input int) string {
 	words := []string{}
 
 	if input < 0 {
-		words = append(words, "minus ")
+		words = append(words, "minus")
 		input *= -1
 	}
 

--- a/nl-nl.go
+++ b/nl-nl.go
@@ -26,7 +26,7 @@ func IntegerToNlNl(input int) string {
 	words := []string{}
 
 	if input < 0 {
-		words = append(words, "minder")
+		words = append(words, "min")
 		input *= -1
 	}
 

--- a/nl-nl_test.go
+++ b/nl-nl_test.go
@@ -16,7 +16,7 @@ func TestIntegerToNlNl(t *testing.T) {
 	t.Parallel()
 
 	tests := map[int]string{
-		-1:            "minder één",
+		-1:            "min één",
 		0:             "nul",
 		1:             "één",
 		9:             "negen",


### PR DESCRIPTION
`minder` means: less, -1 should be worded as `min één` or `minus één`, I'd suggest the former, the latter is a bit more formal, used to indicate a correction is due: off-by-one. The first test should also be adapted, similarly.

Also in German minus there seems a trailing space is added. Not sure if that is a problem

For reference:
https://nl-m-wikipedia-org.translate.goog/wiki/Minteken?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=nl&_x_tr_pto=wapp
see the second dot below use / gebruik (in the dutch explanation)

<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->
