### PR TITLE
fix: 🐛 Fix 'nueve' word usage in number-to-words conversion

### DIFF
--- a/es-es.go
+++ b/es-es.go
@@ -20,7 +20,7 @@ func init() {
 func IntegerToEsEs(input int) string {
 	var spanishMegasSingular = []string{"", "mil", "millón", "mil millones", "billón"}
 	var spanishMegasPlural = []string{"", "mil", "millones", "mil millones", "billones"}
-	var spanishUnitsAdjectives = []string{"", "un", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nove"}
+	var spanishUnitsAdjectives = []string{"", "un", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nueve"}
 	var spanishUnits = []string{"", "uno", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nueve"}
 	var spanishHundreds = []string{"", "ciento", "doscientos", "trescientos", "cuatrocientos", "quinientos", "seiscientos", "setecientos", "ochocientos", "novecientos"}
 	var spanishTens = []string{"", "diez", "veinte", "treinta", "cuarenta", "cincuenta", "sesenta", "setenta", "ochenta", "noventa"}

--- a/es-es_test.go
+++ b/es-es_test.go
@@ -89,6 +89,7 @@ func TestIntegerToEsEs(t *testing.T) {
 		2000000:       "dos millones",
 		4000000:       "cuatro millones",
 		5000000:       "cinco millones",
+		9799001:       "nueve millones setecientos noventa y nueve mil uno",
 		100100100:     "ciento millones ciento mil ciento",
 		500500500:     "quinientos millones quinientos mil quinientos",
 		606606606:     "seiscientos seis millones seiscientos seis mil seiscientos seis",


### PR DESCRIPTION
Correction in the word 'nueve'. In previous tests, the results for the numbers 3,609,101 and 9,799,001 were being obtained as 'nove millones setecientos noventa y nueve mil uno' and 'tres millones seiscientos nove mil ciento uno' when using 'IntegerToEsEs'.